### PR TITLE
Adding party validation to raw_data trigger.

### DIFF
--- a/sql/3_db-functions.sql
+++ b/sql/3_db-functions.sql
@@ -550,6 +550,8 @@ BEGIN
 
     	  IF data_person_id IS NOT NULL THEN
     	    UPDATE respondent SET party_id = data_person_id WHERE id = data_respondent_id;
+          -- validate party
+          UPDATE party SET validated = true WHERE id = data_person_id;
     	  ELSE
     	    RAISE EXCEPTION 'Cannot create party %',party_type;
     	  END IF;


### PR DESCRIPTION
Parties should be validated when ingesting json from ONA otherwise the UI chokes on null values.
